### PR TITLE
Add missing local variable

### DIFF
--- a/digilines_inventory/init.lua
+++ b/digilines_inventory/init.lua
@@ -127,8 +127,9 @@ minetest.register_node("digilines_inventory:chest", {
 		minetest.log("action", player:get_player_name().." puts stuff into chest at "..minetest.pos_to_string(pos))
 	end,
 	on_metadata_inventory_take = function(pos, listname, index, stack, player)
-		local channel = minetest.get_meta(pos):get_string("channel")
-		local inv = minetest.get_meta(pos):get_inventory()
+		local meta = minetest.get_meta(pos)
+		local channel = meta:get_string("channel")
+		local inv = meta:get_inventory()
 		if inv:is_empty(listname) then
 			sendMessage(pos, "empty", channel)
 		end

--- a/digilines_inventory/init.lua
+++ b/digilines_inventory/init.lua
@@ -127,6 +127,7 @@ minetest.register_node("digilines_inventory:chest", {
 		minetest.log("action", player:get_player_name().." puts stuff into chest at "..minetest.pos_to_string(pos))
 	end,
 	on_metadata_inventory_take = function(pos, listname, index, stack, player)
+		local channel = minetest.get_meta(pos):get_string("channel")
 		local inv = minetest.get_meta(pos):get_inventory()
 		if inv:is_empty(listname) then
 			sendMessage(pos, "empty", channel)


### PR DESCRIPTION
The on_metadata_inventory_take method of digiline_inventory:chest was
broken, since it used a `channel` local variable that was never defined,
but should have been fetched from the node's meta.